### PR TITLE
rt - create database table for UCSBOrganization

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/entities/UCSBOrganization.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/UCSBOrganization.java
@@ -1,0 +1,21 @@
+package edu.ucsb.cs156.example.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/** This is a JPA entity that represents UCSB Organizations */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "ucsborganizations")
+public class UCSBOrganization {
+  @Id private String orgCode;
+  private String orgTranslationShort;
+  private String orgTranslation;
+  private boolean inactive;
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/UCSBOrganizationRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/UCSBOrganizationRepository.java
@@ -1,0 +1,11 @@
+package edu.ucsb.cs156.example.repositories;
+
+import edu.ucsb.cs156.example.entities.UCSBOrganization;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
+import org.springframework.stereotype.Repository;
+
+/** The UCSBOrganizationRepository is a repository for UCSBOrganization entities */
+@Repository
+@RepositoryRestResource(exported = false)
+public interface UCSBOrganizationRepository extends CrudRepository<UCSBOrganization, String> {}

--- a/src/main/resources/db/migration/changes/UCSBOrganization.json
+++ b/src/main/resources/db/migration/changes/UCSBOrganization.json
@@ -11,7 +11,7 @@
               "not": [
                 {
                   "tableExists": {
-                    "tableName": "UCSBORGANIZATION"
+                    "tableName": "UCSBORGANIZATIONS"
                   }
                 }
               ]
@@ -53,7 +53,7 @@
                     }
                   }]
                 ,
-                "tableName": "UCSBORGANIZATION"
+                "tableName": "UCSBORGANIZATIONS"
               }
             }]
 

--- a/src/main/resources/db/migration/changes/UCSBOrganization.json
+++ b/src/main/resources/db/migration/changes/UCSBOrganization.json
@@ -1,0 +1,62 @@
+{ "databaseChangeLog": [
+    {
+        "changeSet": {
+          "id": "UCSBOrganization-1",
+          "author": "rushabhtaneja",
+          "preConditions": [
+            {
+              "onFail": "MARK_RAN"
+            },
+            {
+              "not": [
+                {
+                  "tableExists": {
+                    "tableName": "UCSBORGANIZATION"
+                  }
+                }
+              ]
+            }
+          ],
+          "changes": [
+            {
+              "createTable": {
+                "columns": [
+                  {
+                    "column": {
+                      "constraints": {
+                        "primaryKey": true,
+                        "primaryKeyName": "UCSBORGANIZATION_PK"
+                      },
+                      "name": "ORG_CODE",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "ORG_TRANSLATION_SHORT",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "ORG_TRANSLATION",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "constraints": {
+                        "nullable": false
+                      },
+                      "name": "ACTIVE",
+                      "type": "BOOLEAN"
+                    }
+                  }]
+                ,
+                "tableName": "UCSBORGANIZATION"
+              }
+            }]
+
+        }
+    }
+]}

--- a/src/main/resources/db/migration/changes/UCSBOrganization.json
+++ b/src/main/resources/db/migration/changes/UCSBOrganization.json
@@ -48,7 +48,7 @@
                       "constraints": {
                         "nullable": false
                       },
-                      "name": "ACTIVE",
+                      "name": "INACTIVE",
                       "type": "BOOLEAN"
                     }
                   }]


### PR DESCRIPTION
Closes #14 

In this PR we add a database table that represents UCSB Organization, with the following fields:

```
String orgCode
String orgTranslationShort
String orgTranslation
boolean inactive
```

You can test this by running on local host and looking for the UCSBOrganization table on h2-console.

<img width="466" height="202" alt="image" src="https://github.com/user-attachments/assets/b7ce45b6-e96d-4b83-9fcf-3aaa8163aa8b" />

You can also test by running on dokku and connecting to postgres database and running \dt:

```
rushabh@dokku-11:~$ dokku postgres:connect team01-dev-rushabhtaneja-db
psql (15.2 (Debian 15.2-1.pgdg110+1))
SSL connection (protocol: TLSv1.3, cipher: TLS_AES_256_GCM_SHA384, compression: off)
Type "help" for help.

team01_dev_rushabhtaneja_db=# \dt
                 List of relations
 Schema |          Name          | Type  |  Owner   
--------+------------------------+-------+----------
 public | articles               | table | postgres
 public | databasechangelog      | table | postgres
 public | databasechangeloglock  | table | postgres
 public | jobs                   | table | postgres
 public | recommendationrequests | table | postgres
 public | restaurants            | table | postgres
 public | ucsbdates              | table | postgres
 public | ucsbdiningcommons      | table | postgres
 public | ucsborganization       | table | postgres
 public | urls                   | table | postgres
 public | users                  | table | postgres
(11 rows)

team01_dev_rushabhtaneja_db=# 
```